### PR TITLE
feat api newReview-utils updates products average as reviews are added

### DIFF
--- a/api/src/utils/newReview-utils.js
+++ b/api/src/utils/newReview-utils.js
@@ -1,13 +1,27 @@
-const { fn,col } = require("sequelize");
-const { Review, User, Product, conn } = require("../db.js");
+const { Review, User, Product } = require("../db.js");
 
 module.exports = {
     newReview: async (review, rate, userId, productId) => {
+        // Verificar que el usuario no tenga ya un review para este producto.
+
+        const previousReview = await Review.findAll({
+            where:{
+                productId: productId,
+                userId: userId
+            },
+            include: Product, User
+        })
+
+        if (previousReview.length > 0) throw Error ('The user had already reviewed the product')
+
+        // Si no hay reviews previos, lo guardamos
+
         const saveReview = await Review.create({
             comment: review,
             rate
         });
         if (!saveReview) throw Error ('The review cant be saved');
+        
         await saveReview.setUser(userId);
         await saveReview.setProduct(productId);
 
@@ -30,8 +44,6 @@ module.exports = {
         })
 
         product = await product.save()
-
-        console.log(product.rating)
 
         return saveReview;
     }

--- a/api/src/utils/newReview-utils.js
+++ b/api/src/utils/newReview-utils.js
@@ -1,4 +1,5 @@
-const { Review, User, Product } = require("../db");
+const { fn,col } = require("sequelize");
+const { Review, User, Product, conn } = require("../db.js");
 
 module.exports = {
     newReview: async (review, rate, userId, productId) => {
@@ -9,6 +10,29 @@ module.exports = {
         if (!saveReview) throw Error ('The review cant be saved');
         await saveReview.setUser(userId);
         await saveReview.setProduct(productId);
+
+        // Actualizamos el rating promedio cada vez que se hace un review de un producto
+
+        const productRatings = await Review.findAll({
+            where: { productId: productId },
+            include: Product,
+        })
+
+        const productRatingSum = productRatings.reduce( (sum, review) => {
+            return review.rate + sum
+        },0)
+        
+        const productAverageRating = productRatingSum / productRatings.length
+
+        let product = await Product.findByPk(productId)
+        product.set({
+            rating: productAverageRating
+        })
+
+        product = await product.save()
+
+        console.log(product.rating)
+
         return saveReview;
     }
 }


### PR DESCRIPTION
Según lo que pude investigar, no es posible poner un campo virtual que use info de otros modelos, terminé haciéndolo en el controller _api/src/utils/newReview-utils.js_. Ahora, al momento de crear la row del review en la base de datos, también actualiza el rating promedio del producto en cuestión.
![Screenshot_20220324_112554](https://user-images.githubusercontent.com/13108994/159975299-ce7cf88c-c85f-4258-b4f4-d70e39b1adb0.png)
![Screenshot_20220324_112624](https://user-images.githubusercontent.com/13108994/159975311-08c5bf42-b3af-462a-b6ea-dbcb724ba1e9.png)
